### PR TITLE
Show reviewers not targets

### DIFF
--- a/rb_stats.py
+++ b/rb_stats.py
@@ -19,18 +19,18 @@ def parse_req_params(pargs):
 
 def get_graph_data(args):
     req_params = parse_req_params(vars(args))
-
-    ret = requests.get(args.base_api_url + '/review-requests',
-                       params=req_params)
+    root = requests.get(args.base_api_url)
+    requests_list = requests.get(root.json['links']['review_requests']['href'],
+                                 params=req_params)
 
     graph_data = defaultdict(int)
 
-    for review in ret.json['review_requests']:
-        submitter = review['links']['submitter']['title']
-
-        for people in review['target_people']:
-            reviewer = people['title']
-            graph_data[(submitter, reviewer)] += 1.0
+    for review_request in requests_list.json['review_requests']:
+        submitter = review_request['links']['submitter']['title']
+        reviews = requests.get(review_request['links']['reviews']['href'])
+        for review in reviews.json['reviews']:
+            reviewer = review['links']['user']['title']
+            graph_data[(submitter, reviewer)] += 1
     return graph_data
 
 

--- a/rb_stats.py
+++ b/rb_stats.py
@@ -17,6 +17,23 @@ def parse_req_params(pargs):
     return dparams
 
 
+def get_graph_data(args):
+    req_params = parse_req_params(vars(args))
+
+    ret = requests.get(args.base_api_url + '/review-requests',
+                       params=req_params)
+
+    graph_data = defaultdict(int)
+
+    for review in ret.json['review_requests']:
+        submitter = review['links']['submitter']['title']
+
+        for people in review['target_people']:
+            reviewer = people['title']
+            graph_data[(submitter, reviewer)] += 1.0
+    return graph_data
+
+
 def run_main():
     parser = argparse.ArgumentParser(description='Review Board Stats')
     parser.add_argument('base_api_url', help='The ReviewBoard base API URL')
@@ -43,20 +60,7 @@ def run_main():
                                  'hanning', 'hamming', 'gaussian'])
 
     args = parser.parse_args()
-    req_params = parse_req_params(vars(args))
-
-    ret = requests.get(args.base_api_url + '/review-requests',
-                       params=req_params)
-
-    graph_data = defaultdict(int)
-
-    for review in ret.json['review_requests']:
-        submitter = review['links']['submitter']['title']
-
-        for people in review['target_people']:
-            reviewer = people['title']
-            graph_data[(submitter, reviewer)] += 1.0
-
+    graph_data = get_graph_data(args)
     xaxis = list(set(map(lambda x: x[0], graph_data.keys())))
     yaxis = list(set(map(lambda x: x[1], graph_data.keys())))
 


### PR DESCRIPTION
These changes are more substantial, and more controversial I suspect!

I was perplexed when I first ran rb_stats.py against my ReviewBoard server (with several hundred if not thousand of review requests) to only see one entry on the x-axis and one on the y-axis. My expectation was that the graph contained Submitters vs. Reviewers (i.e. people who had performed a review on a Review Request). Instead what I was actually seeing was Submitters vs. Target People; my ReviewBoard workflow uses Target Groups not specific people (apart from on the odd occasion - see the one entry!). 

This set of changes makes rb_stats.py meet my expectations and plot the Submitters vs. Reviewers, but it does introduce a large performance penalty (as noted on a comment on commit 2f51f0c117b7102a1bc6af2f3c19cec9ae1841a2 ). The effect is exaggerated on Apache's ReviewBoard due to network latency - on my in-house ReviewBoard server, with the `.show()` commented out and no max-results override it takes 40s which I consider reasonable.

I'm open to suggestions as to how to improve this, or perhaps move it behind a command line flag.
